### PR TITLE
SLES4SAP-hana-sr-guide-PerfOpt-12.adoc: order Optional:

### DIFF
--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
@@ -3029,7 +3029,7 @@ clone cln_SAPHanaTopology_{sapsid}_HDB{sapino} rsc_SAPHanaTopology_{sapsid}_HDB{
         meta clone-node-max=1 interleave=true
 colocation col_saphana_ip_{sapsid}_HDB{sapino} 2000: \
         rsc_ip_{sapsid}_HDB{sapino}:Started msl_SAPHana_{sapsid}_HDB{sapino}:Master
-order ord_SAPHana_{sapsid}_HDB{sapino} 2000: \
+order ord_SAPHana_{sapsid}_HDB{sapino} Optional: \
         cln_SAPHanaTopology_{sapsid}_HDB{sapino} msl_SAPHana_{sapsid}_HDB{sapino}
 property cib-bootstrap-options: \
         dc-version="1.1.19+20180928.0d2680780-1.8-1.1.19+20180928.0d2680780" \


### PR DESCRIPTION
Example Cluster Configuration:

https://documentation.suse.com/sbp/sap-12/html/SLES4SAP-hana-sr-guide-PerfOpt-12/index.html#id-example-cluster-configuration

We should suggest to use "Optional" and not "2000" when configuring the order as we already did here in the same guide:
https://documentation.suse.com/sbp/sap-12/html/SLES4SAP-hana-sr-guide-PerfOpt-12/index.html#id-constraints

`order ord_SAPHana_HA1_HDB10 Optional: cln_SAPHanaTopology_HA1_HDB10 \ msl_SAPHana_HA1_HDB10`